### PR TITLE
Depreciation/User warning filter for startup

### DIFF
--- a/plugin/client.vim
+++ b/plugin/client.vim
@@ -27,6 +27,10 @@ warnings.filterwarnings('ignore',
     '.*',
     UserWarning,)
 
+warnings.filterwarnings('ignore',
+    '.*',
+    DeprecationWarning,)
+
 from twisted.internet.protocol import ClientFactory, Protocol
 #from twisted.protocols.basic import LineReceiver
 from twisted.internet import reactor


### PR DESCRIPTION
Hi these commits are a possible solution for suppressing  the Depreciation type warnings on startup that occasionally crop up. Eg. I am seeing locally.

...........
Error detected while processing 
/home/michael/dotfiles/_vim/bundle/CoVim/plugin/client.vim:
line  316:
/usr/lib/python2.7/dist-packages/zope/__init__.py:3: UserWarning: Module cms was already ... 
..........

before the plugin loads. Even though the warning isn't being generated by your code itself. I think its a limitation with vim's python interpreter.

Regards,

Michael
