### PR TITLE
Find the path to plugin.py more reliably

### DIFF
--- a/plugin/client.vim
+++ b/plugin/client.vim
@@ -31,12 +31,8 @@ from time import sleep
 warnings.filterwarnings('ignore','.*', UserWarning)
 warnings.filterwarnings('ignore','.*', DeprecationWarning)
 
-# Check for Vundle/Pathogen
-if os.path.exists(os.path.expanduser('~') + '/.vim/bundle/CoVim/plugin'):
-  CoVimServerPath = '~/.vim/bundle/CoVim/plugin/server.py'
-else:
-  CoVimServerPath = '~/.vim/plugin/server.py'
-
+# Find the server path
+CoVimServerPath = vim.eval('expand("<sfile>:h")') + '/server.py'
 
 ## CoVim Protocol
 class VimProtocol(Protocol):


### PR DESCRIPTION
When the bundle created is not called `CoVim`, for example, the plugin doesn't work at all, and there's no reasonable error message. I believe using vimscript to get the path to `client.vim` and find the related `server.py` would be more stable.
