### PR TITLE
Error out upon usage, not upon loading

### DIFF
--- a/plugin/client.vim
+++ b/plugin/client.vim
@@ -1,7 +1,9 @@
 if !has('python')
-  echo "Error: Required vim compiled with +python"
+  com! -nargs=* CoVim echoerr "Error: Required vim compiled with +python"
   finish
 endif
+
+com! -nargs=+ CoVim py CoVim.command(<f-args>)
 
 "Needs to be set on connect, MacVim overrides otherwise"
 function! SetCoVimColors ()
@@ -311,5 +313,3 @@ class CoVimScope:
 
 CoVim = CoVimScope()
 EOF
-
-com! -nargs=+ CoVim py CoVim.command(<f-args>)


### PR DESCRIPTION
If you don't have python for whatever reason, you get an error upon every vim startup. It would be nice to get the error upon usage instead -- you could easily have different Vim builds on different computers or something. Alternatively, what most plugins do is just `finish` without defining the command, but maybe this method would be more useful.
