### PR TITLE
Now works correctly if other (non-shared) buffers exist

### DIFF
--- a/plugin/CoVimClient.vim
+++ b/plugin/CoVimClient.vim
@@ -297,8 +297,8 @@ class CoVimScope:
     def setupWorkspace(self):
         vim.command('call SetCoVimColors()')
         vim.command(':autocmd!')
-        vim.command('autocmd CursorMoved * py reactor.callFromThread(CoVim.fact.cursor_update)')
-        vim.command('autocmd CursorMovedI * py reactor.callFromThread(CoVim.fact.buff_update)')
+        vim.command('autocmd CursorMoved <buffer> py reactor.callFromThread(CoVim.fact.cursor_update)')
+        vim.command('autocmd CursorMovedI <buffer> py reactor.callFromThread(CoVim.fact.buff_update)')
         vim.command('autocmd VimLeave * py CoVim.quit()')
         vim.command("1new +setlocal\ stl=%!'CoVim-Collaborators'")
         self.buddylist = vim.current.buffer


### PR DESCRIPTION
Without this change, CoVim will get very confused, if the user switches to some other window. No longer!
