### PR TITLE
Rename server.py to CoVimServer.py in all the places

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Also note that the Twisted & Argparse libraries can also be installed via apt-ge
 > If you're still having trouble, [visit the wiki](https://github.com/FredKSchott/CoVim/wiki) for addition troubleshooting & FAQ 
 
 ##Usage
-__To start a new CoVim server:__ `:CoVim start [port] [name]` (or, from the command line: `./server.py [port]`)  
+__To start a new CoVim server:__ `:CoVim start [port] [name]` (or, from the command line: `./CoVimServer.py [port]`)  
 __To connect to a running server:__ `:CoVim connect [host address / 'localhost'] [port] [name]`  
 __To disconnect:__ `:CoVim disconnect`  
 __To quit Vim while CoVim is connected:__ `:CoVim quit` or `:qall!`

--- a/doc/CoVim.txt
+++ b/doc/CoVim.txt
@@ -35,7 +35,7 @@ USAGE                                                            *covim-usage*
 
 To start a new CoVim server:
   :CoVim start [port] [name] 
-  (or, start a CoVim server from the command line: ./server.py [port])
+  (or, start a CoVim server from the command line: ./CoVimServer.py [port])
 
 To connect to a running server:
   :CoVim connect [host address / 'localhost'] [port] [name]


### PR DESCRIPTION
Further to 3a0e29acdb021b29bfbaeea5231a9298cc4e087d, rename `server.py` to `CoVimServer.py` in the documentation.
